### PR TITLE
#152071672 retrieve-recipes screen

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
     
-    "plugins": ["transform-runtime"],
+    "plugins": ["transform-runtime", "transform-object-rest-spread"],
       
     "presets": [
         "es2015", "react"

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -78,6 +78,9 @@ button,.link-button{
  background-color: white;
 
 }
+button.btn.btn-default:disabled {
+  cursor: not-allowed;
+}
 input, textarea{
  font-family: kaushan script;
  color:gray;

--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open
   +Sans|Kaushan+Script">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.css">
   <title>Document</title>
 </head>
 <body class ="bg">

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import Login from './screens/Login';
 import Register from './screens/Register';
 import CreateRecipe from './screens/CreateRecipe';
-import ViewRecipe from './screens/ViewRecipe'
+import ViewRecipe from './screens/ViewRecipe';
 import axios from 'axios';
 import { syncHistoryWithStore } from 'react-router-redux'
 

--- a/client/src/components/AddReview.jsx
+++ b/client/src/components/AddReview.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { createReview } from '../store/actions';
+ 
+/**
+ * Add a review component
+ * @returns {obj} jsx object
+ */
+class AddReview extends React.Component {
+  /**
+   * Render the component jsx
+   * @returns {obj} jsx
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      review: ''
+    }
+
+    this.handleChange = this.handleChange.bind(this);
+    this.createReview = this.createReview.bind(this);
+  }
+  createReview() {
+    this.props.createReview(this.state.review, this.props.recipeId);
+    this.setState({
+      review: ''
+    });
+  }
+
+  handleChange(event) {
+    this.setState({
+      review: event.target.value
+    });
+  }
+
+  render() {
+    return (
+      <div className="form-group">
+        <textarea cols="120" onChange={this.handleChange} className="form-control mb-3" value={this.state.review} placeholder="Add review ..."></textarea>
+        <button className="btn btn-default" disabled={this.state.review.length < 8} onClick={this.createReview}>Add Review</button>
+      </div>
+    );
+  }
+}
+
+const mapDispatchToProps = dispatch => bindActionCreators({ createReview }, dispatch);
+const AddReviewContainer = connect(null, mapDispatchToProps)(AddReview);
+
+export default AddReviewContainer;

--- a/client/src/components/IngredientList.jsx
+++ b/client/src/components/IngredientList.jsx
@@ -1,7 +1,11 @@
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const IngredientList =  ({ ingredients }) => {
+  ingredients = ingredients.trim();
+  if (ingredients[ingredients.length - 1] === ',') {
+    ingredients = ingredients.substr(0, ingredients.length - 1);
+  }
   let ingredientsArray = ingredients.split(",");
   let ingredientsList = ingredientsArray.map((ingredient, index) => <li style={{fontSize: '18px'}} key={index}>{ingredient}</li>);
    return(
@@ -15,5 +19,4 @@ IngredientList.propTypes = {
   ingredients: PropTypes.string.isRequired
 };
 
- export default IngredientList;
-  
+export default IngredientList;

--- a/client/src/components/MethodList.jsx
+++ b/client/src/components/MethodList.jsx
@@ -1,8 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const MethodList =  (props) => {
-  let methodArray = props.method.split(".");
+const MethodList =  ({ method }) => {
+  method = method.trim();
+  if (method[method.length - 1] === '.') {
+    method = method.substr(0, method.length - 1);
+  }
+  let methodArray = method.split(".");
   let methodList = methodArray.map((method, index) => <li style={{fontSize: '18px'}} key={index}>{method}. </li>);
    return(
     <ul className="text-justify" style={{paddingBottom: 50}}>

--- a/client/src/components/Notification.jsx
+++ b/client/src/components/Notification.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Noty from 'noty';
+import toastr from 'toastr';
+import { connect } from 'react-redux';
+
+class Notification extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    if (this.props.notification && this.props.notification.level === 'SUCCESS') {
+      console.log(this.props.notification);
+      new Noty({
+        text: this.props.notification.message,
+        type: 'success',
+        theme: 'bootstrap-v4',
+        timeout: 3000
+      }).show();
+    }
+    return <div></div>
+  }
+}
+
+const mapStateToProps = state => ({ notification: state.notification });
+
+const NotificationContainer = connect(mapStateToProps, null)(Notification);
+
+export default NotificationContainer;
+

--- a/client/src/components/ReviewList.jsx
+++ b/client/src/components/ReviewList.jsx
@@ -7,7 +7,7 @@ const ReviewList =  (props) => {
   let ReviewList = ReviewArray.map((review, index) => <div style={{fontSize: '18px'}}  key={index} 
     style={{borderBottom: '1px solid lightgrey', marginBottom: 20}} >
     <p >{review.review}</p><p><i className="fa fa-user-circle-o" aria-hidden="true" />
-    &nbsp; CollinsAbeen</p></div>);
+    &nbsp; {review.User.Username}</p></div>);
    return(
     <article style={{paddingBottom: 30}}>
       {ReviewList}

--- a/client/src/containers/Main.jsx
+++ b/client/src/containers/Main.jsx
@@ -1,8 +1,9 @@
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as actions from './../store/actions';
+import Notification from './../components/Notification';
 
 class App extends React.Component {
   constructor(props) {
@@ -11,9 +12,10 @@ class App extends React.Component {
   render() {
 
     return (
-      <div>
+      <Fragment>
+        <Notification />
         {this.props.children}
-      </div>
+      </Fragment>
     );
   }
 }

--- a/client/src/screens/CreateRecipe.jsx
+++ b/client/src/screens/CreateRecipe.jsx
@@ -6,8 +6,9 @@ import Footer from '../components/Footer';
 import ImageFile from '../components/ImageUploader'
 import { Link } from 'react-router';
 import { createRecipe } from '../store/actions';
-import { checkField } from '../helpers'
+import { checkField } from '../helpers';
 import '../../assets/css/style.css';
+import AddReview from './../components/AddReview';
 
 class CreateRecipeScreen extends React.Component {
   constructor(props) {

--- a/client/src/screens/ViewRecipe.jsx
+++ b/client/src/screens/ViewRecipe.jsx
@@ -9,7 +9,7 @@ import Footer from '../components/Footer';
 import { Link } from 'react-router';
 import { getRecipe } from '../store/actions';
 import food9 from '../../assets/image/food-9.jpg';
-
+import AddReview from './../components/AddReview';
 import '../../assets/css/style.css';
 
 class ViewRecipeScreen extends React.Component {
@@ -102,8 +102,8 @@ class ViewRecipeScreen extends React.Component {
             <section className="text-justify" style={{paddingLeft: 50, paddingRight: 50}}>
                 <ReviewList reviews={recipe.Reviews}/>
             </section>
-            <div className="row">
-              <button type="button" className="btn btn-default" style={{marginLeft: 10, marginBottom: 20}}>Add Review</button>
+            <div className="row justify-content-center">
+                <AddReview recipeId={recipe.id}/>
             </div>
           </section>
           <Footer/>

--- a/client/src/store/actions/index.js
+++ b/client/src/store/actions/index.js
@@ -20,9 +20,6 @@ export function signInUser({Username, Password}) {
       });
       localStorage.setItem('authUser', JSON.stringify(response.data));
 
-      
-      return;
-
       dispatch ({
         type: 'SIGN_IN_USER',
         authUser: response.data
@@ -104,6 +101,28 @@ export function getRecipe(recipeId) {
       });
       return Promise.resolve();
     } catch (error) {
+      return Promise.reject();
+    }
+  };
+}
+
+export function createReview(review, recipeId) {
+  return async (dispatch, getState) => {
+    try {
+      const response = await axios.post(`http://localhost:4044/api/v1/reviews/${recipeId}`, { review });
+        dispatch({
+          type: 'ADD_RECIPE_REVIEW',
+          payload: response.data.review
+        });
+        dispatch({
+          type: 'NOTIFICATION',
+          payload: {
+            level: 'SUCCESS',
+            message: 'Review created successfully.'
+          }
+        });
+        return Promise.resolve();
+    } catch(error) {
       return Promise.reject();
     }
   };

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -8,7 +8,8 @@ const defaultState = {
   recipes: [],
   imageUpload: {
     imageFile: null
-  }
+  },
+  notification: null
 };
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

--- a/client/src/store/reducers/index.js
+++ b/client/src/store/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
 import recipesReducer from './recipesReducer';
+import notificationsReducer from './notificationsReducer';
 import imageUploadReducer from './imageUploadReducer';
 import authenticationReducer from './authenticationReducer';
 
@@ -9,5 +10,6 @@ export default combineReducers({
   recipes: recipesReducer,
   authUser: authenticationReducer,
   routing: routerReducer,
-  imageUpload: imageUploadReducer
+  imageUpload: imageUploadReducer,
+  notification: notificationsReducer
 });

--- a/client/src/store/reducers/notificationsReducer.js
+++ b/client/src/store/reducers/notificationsReducer.js
@@ -1,0 +1,8 @@
+export default (state = {}, action) => {
+  switch (action.type) {
+    case 'NOTIFICATION':
+      return action.payload;
+    default:
+      return state;
+  }
+};

--- a/client/src/store/reducers/recipesReducer.js
+++ b/client/src/store/reducers/recipesReducer.js
@@ -12,6 +12,20 @@ export default function recipesReducer(state = [], action) {
         ...state,
         action.payload
       ];
+    case 'ADD_RECIPE_REVIEW':
+      return state.map((recipe) => {
+        if (recipe.id !== action.payload.recipeId) {
+          return recipe;
+        }
+
+        return {
+          ...recipe,
+          Reviews: [
+            ...recipe.Reviews,
+            action.payload
+          ]
+        };
+      });
     default:
       return state;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6952,6 +6952,11 @@
         "merge-stream": "1.0.1"
       }
     },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -8051,6 +8056,11 @@
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
       }
+    },
+    "noty": {
+      "version": "3.2.0-beta",
+      "resolved": "https://registry.npmjs.org/noty/-/noty-3.2.0-beta.tgz",
+      "integrity": "sha512-a1//Rth1MTQ/GCvGzwBXrZqCwOPyxiIKMdHT1TlcdrDYBYVfb7vzwsU0N4x+j/HeIQTi6/pbP8lRtY9gBz/d3Q=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -12253,6 +12263,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "toastr": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/toastr/-/toastr-2.1.4.tgz",
+      "integrity": "sha1-i0O+ZPudDEFIcURvLbjoyk6V8YE=",
+      "requires": {
+        "jquery": "3.2.1"
+      }
     },
     "toposort": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mocha": "^4.0.1",
     "morgan": "^1.9.0",
     "nodemon": "^1.12.1",
+    "noty": "^3.2.0-beta",
     "nyc": "^11.2.1",
     "pg": "^7.3.0",
     "pg-hstore": "^2.3.2",
@@ -62,7 +63,8 @@
     "redux-thunk": "^2.2.0",
     "run": "^1.4.0",
     "sequelize": "^4.27.0",
-    "sequelize-cli": "^3.2.0"
+    "sequelize-cli": "^3.2.0",
+    "toastr": "^2.1.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -70,6 +72,7 @@
     "babel-eslint": "^7.2.3",
     "babel-jest": "^22.0.4",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",

--- a/server/controllers/reviews.js
+++ b/server/controllers/reviews.js
@@ -1,7 +1,7 @@
 import db from '../models';
 import { checkField, returnParameter } from '../helpers/checkInput';
 
-const { Recipe, Review } = db;
+const { Recipe, Review, User } = db;
 
 /**
  * Controls the reviews endpoints
@@ -25,11 +25,15 @@ export default class ReviewsController {
           review: req.body.review,
           recipeId: recipe.id,
           userId: req.AuthUser.id
-        }).then(review => res.status(201).json({
-          recipe,
-          review,
-          message: 'Review successfully added!'
-        }));
+        }).then(review => {
+          return Review.findById(review.id, {
+            include: [{ model: User, exclude: 'Password' }]
+          }).then(reviewWithUser => res.status(201).json({
+            recipe,
+            review: reviewWithUser,
+            message: 'Review successfully added!'
+          }));
+        });
       } else {
         return res.status(404).json({
           message: 'Recipe to be reviewed not found'

--- a/server/models/review.js
+++ b/server/models/review.js
@@ -13,23 +13,15 @@ module.exports = (sequelize, DataTypes) => {
         model: 'Users', key: 'id'
       }
     },
-  }, {
-    classMethods: {
-      /**
-   * declares associations
-   * @param {object} models
-   * @returns {integer} foreign key declared
-   */
-      associate(models) {
-        Review.belongsTo(models.Recipe, {
-          foreignKey: 'recipeId'
-        });
-        Review.belongsTo(models.User, {
-          foreignKey: 'userId',
-          as: 'user'
-        });
-      }
-    }
   });
+  
+  Review.associate = models => {
+    Review.belongsTo(models.Recipe, {
+      foreignKey: 'recipeId'
+    });
+    Review.belongsTo(models.User, {
+      foreignKey: 'userId'
+    });
+  };
   return Review;
 };

--- a/template/index-2.html
+++ b/template/index-2.html
@@ -108,7 +108,7 @@
           </div>
         </section>
       <footer class="fixed-bottom"style="background-color: rgba(73, 67, 67, 0.9); max-width: 100%; height: 30px">
-        <p class="text-center" style="margin-bottom: 5px; padding-top:5px; color: #fff; font-size:12px">&copy 2017 More-Recipes</p>
+        <p class="text-center" style="margin-bottom: 5px; padding-top:5px; color: rgb(255, 255, 255); font-size:12px">&copy 2017 More-Recipes</p>
     
       </footer>
     


### PR DESCRIPTION
#### What does this PR do?
create retrieve-recipes screen

#### Description of Task to be completed?
- add transform-object-rest-spread plugin to babelrec file
- install noty for in-app notifications
- add the noty cdn to index.html
- add disable cursor to review button for empty text area
- add view-recipe screen to app.js
- add add-review component
- add trim to ingredients list component
- add trim to method list component
- add notification component
- add dynamic username to review-list component
- add fragment and notification tags to main.jsx file
- add add-review to create-recipe.jsx file
- add add-review to view-recipe.jsx file
- add notification to index.js file
- add notification to reducer index file
- add notifications reducer
- add recipe review reducer
- make changes to review-model to allow for eager-loading of reviews and users

#### How should this be manually tested?
navigating to ```/view-recipe/:recipeId``` retrieves the recipe with specified recipeId

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#152071672

#### Screenshots (if appropriate)
<img width="1435" alt="screen shot 2018-01-22 at 1 27 29 pm" src="https://user-images.githubusercontent.com/32877365/35220824-160efff2-ff78-11e7-83d9-d0c98dadea5f.png">


#### Questions:
N/A